### PR TITLE
Updated get_site_root_url to return URL with protocol and host

### DIFF
--- a/wp-cdn-rewrite.php
+++ b/wp-cdn-rewrite.php
@@ -136,10 +136,19 @@ if( !class_exists( 'CDN_Rewrite' ) ){
 		public function get_site_root_url() {
 			if(is_multisite() && !is_subdomain_install()) {
 				$root_blog = get_blog_details(1);
-				$root_url = $root_blog->siteurl;
+				$root_site_url = $root_blog->siteurl;
 			} else {
-				$root_url = site_url();
+				$root_site_url = site_url();
 			}
+
+			$parsed_root_site_url = parse_url($root_site_url);
+
+			if (array_key_exists('scheme', $parsed_root_site_url)) {
+				$root_url_scheme = $parsed_root_site_url['scheme'] . '://';
+			} else {
+				$root_url_scheme = '//';
+			}
+			$root_url = $root_url_scheme . $parsed_root_site_url['host'];
 			return $root_url;
 		}
 


### PR DESCRIPTION
It's possible for a WP site to be configured with a WP_SITEURL that includes a subdirectory path. For instance the [Bedrock](https://github.com/roots/bedrock) configuration defines the WP_SITEURL so that it [points to the 'wp' folder](https://github.com/roots/bedrock/blob/df4e013a/.env.example#L8) under the servers configured website root, because this folder is installed by Composer with the Wordpress core files.

If a CDN is truly providing mirroring, then we don't need to replace anything in the path of the URI, only the protocol and host.

This update ensures that get_site_root_url only returns the protocol and host, while also taking into account the issue reported in #5.
